### PR TITLE
Fix StringIndexOutOfBoundsException when getValue() is called on Entry without value

### DIFF
--- a/src/main/java/com/github/odiszapc/nginxparser/NgxAbstractEntry.java
+++ b/src/main/java/com/github/odiszapc/nginxparser/NgxAbstractEntry.java
@@ -73,14 +73,15 @@ public abstract class NgxAbstractEntry implements NgxEntry {
     }
 
     public String getValue() {
-        List<String> values = getValues();
-
+        Iterator<String> iterator = getValues().iterator();
         StringBuilder builder = new StringBuilder();
-        for (String value : values) {
-            builder.append(value).append(" ");
+        while (iterator.hasNext()) {
+            builder.append(iterator.next());
+            if (iterator.hasNext()) {
+              builder.append(' ');
+            }
         }
-        String s = builder.toString();
-        return s.substring(0, s.length()-1);
+        return builder.toString();
     }
 
 }

--- a/src/test/java/com/github/odiszapc/nginxparser/NestedTest.java
+++ b/src/test/java/com/github/odiszapc/nginxparser/NestedTest.java
@@ -24,6 +24,10 @@ import java.util.List;
 
 import static com.github.odiszapc.nginxparser.TestUtils.assertBlock;
 import static com.github.odiszapc.nginxparser.TestUtils.assertParam;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 public class NestedTest extends ParseTestBase {
 
@@ -47,17 +51,17 @@ public class NestedTest extends ParseTestBase {
         appIt = application.iterator();
         assertParam(appIt.next(), "live", "off");
 
-        Assert.assertFalse(it.hasNext());
+        assertFalse(it.hasNext());
     }
 
     @Test
     public void testC1find() throws Exception {
         NgxConfig conf = parse("nested/c1.conf");
         List<NgxEntry> result = conf.findAll(NgxConfig.PARAM, "rtmp", "server", "application", "live");
-        Assert.assertEquals(result.size(), 2);
+        assertEquals(result.size(), 2);
         assertParam(result.get(0), "live", "on");
         assertParam(result.get(1), "live", "off");
-        Assert.assertNotEquals(result.get(0), result.get(1));
+        assertNotEquals(result.get(0), result.get(1));
     }
 
     @Test
@@ -72,23 +76,23 @@ public class NestedTest extends ParseTestBase {
         assertBlock(s1, "server");
         NgxParam param = s1.findParam("application", "live");
         assertParam(param, "live");
-        Assert.assertEquals(param.getValue(), "on");
+        assertEquals(param.getValue(), "on");
 
         NgxBlock s2 = (NgxBlock) it.next();
         assertBlock(s2, "server");
         NgxParam param2 = s2.findParam("application", "live");
         assertParam(param2, "live");
-        Assert.assertEquals(param2.getValue(), "off");
+        assertEquals(param2.getValue(), "off");
     }
 
     @Test
     public void testC1findBlock() throws Exception {
         NgxConfig conf = parse("nested/c1.conf");
         List<NgxEntry> result = conf.findAll(NgxConfig.BLOCK, "rtmp", "server", "application");
-        Assert.assertEquals(result.size(), 2);
+        assertEquals(result.size(), 2);
         assertBlock(result.get(0), "application", "myapp");
         assertBlock(result.get(1), "application", "myapp2");
-        Assert.assertNotEquals(result.get(0), result.get(1));
+        assertNotEquals(result.get(0), result.get(1));
     }
 
     @Test
@@ -100,5 +104,17 @@ public class NestedTest extends ParseTestBase {
         assertParam(it.next(), "set_unescape_uri", "$name", "$arg_name");
         assertParam(it.next(), "set_if_empty", "$name", "\"Anonymous\"");
         assertParam(it.next(), "memc_pass", "127.0.0.1:11211");
+    }
+
+    @Test
+    public void testС5() throws Exception {
+        NgxConfig conf = parse("nested/c5.conf");
+        NgxBlock loc = assertBlock(conf.findBlock("http", "server", "location"), "location", "/foo");
+        Iterator<NgxEntry> it = loc.iterator();
+        NgxEntry entry = it.next();
+        assertTrue(entry instanceof NgxParam);
+        assertEquals(((NgxParam) entry).getName(), "stub_status");
+        assertEquals(0, ((NgxParam) entry).getValues().size());
+        assertEquals("", ((NgxParam) entry).getValue());
     }
 }

--- a/src/test/resources/nested/c5.conf
+++ b/src/test/resources/nested/c5.conf
@@ -1,0 +1,7 @@
+http {
+  server {
+    location /foo {
+      stub_status;
+    }
+  }
+}


### PR DESCRIPTION
Reason for the problem is that the trailing space is tried to be removed even when there is no value (and thus no trailing whitespace)
There are many solutions to making this work, I opted for controlling the whitespace addition.
The advantage is that there is no need for any substring operation which would create a new string.
