### PR TITLE
Create valid OSGi bundle manifest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <groupId>com.github.odiszapc</groupId>
     <artifactId>nginxparser</artifactId>
     <version>0.9.6</version>
-    <packaging>jar</packaging>
+    <packaging>bundle</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Parses Nginx configuration files with JavaCC grammar based parser</description>
@@ -84,6 +84,12 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.5.4</version>
+                <extensions>true</extensions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
This changes the generated manifest to be OSGi compliant. declaring all imported and exported packages. No other changes in any of the compiled classes

```
Manifest-Version: 1.0
Bnd-LastModified: 1460299170325
Build-Jdk: 1.8.0_71
Built-By: fabian
Bundle-Description: Parses Nginx configuration files with JavaCC grammar
  based parser
Bundle-License: http://www.apache.org/licenses/LICENSE-2.0
Bundle-ManifestVersion: 2
Bundle-Name: com.github.odiszapc:nginxparser
Bundle-SymbolicName: com.github.odiszapc.nginxparser
Bundle-Version: 0.9.6
Created-By: Apache Maven Bundle Plugin
Export-Package: com.github.odiszapc.nginxparser.antlr;version="0.9.6";us
 es:="com.github.odiszapc.nginxparser,org.antlr.v4.runtime,org.antlr.v4.
 runtime.atn,org.antlr.v4.runtime.dfa,org.antlr.v4.runtime.tree",com.git
 hub.odiszapc.nginxparser.javacc;version="0.9.6";uses:="com.github.odisz
 apc.nginxparser",com.github.odiszapc.nginxparser;version="0.9.6";uses:=
 "com.github.odiszapc.nginxparser.javacc"
Import-Package: org.antlr.v4.runtime;version="[4.5,5)",org.antlr.v4.runt
 ime.atn;version="[4.5,5)",org.antlr.v4.runtime.dfa;version="[4.5,5)",or
 g.antlr.v4.runtime.tree;version="[4.5,5)"
Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.6))"
Tool: Bnd-2.4.1.201501161923
```
