### PR TITLE
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/src/main/java/com/github/odiszapc/nginxparser/NgxEntryType.java
+++ b/src/main/java/com/github/odiszapc/nginxparser/NgxEntryType.java
@@ -27,16 +27,15 @@ public enum NgxEntryType {
 
     private final Class<? extends NgxEntry> clazz;
 
-    Class<? extends NgxEntry> getType() {
-        return clazz;
-    }
+    private static Map<Class<? extends NgxEntry>, NgxEntryType> types;
 
     NgxEntryType(Class<? extends NgxEntry> clazz) {
-
         this.clazz = clazz;
     }
 
-    private static Map<Class<? extends NgxEntry>, NgxEntryType> types;
+    Class<? extends NgxEntry> getType() {
+        return clazz;
+    }
 
     static {
         types = new HashMap<Class<? extends NgxEntry>, NgxEntryType>();

--- a/src/main/java/com/github/odiszapc/nginxparser/javacc/NginxConfigParser.java
+++ b/src/main/java/com/github/odiszapc/nginxparser/javacc/NginxConfigParser.java
@@ -6,6 +6,70 @@ import com.github.odiszapc.nginxparser.*;
 public class NginxConfigParser implements NginxConfigParserConstants {
   private boolean isDebug = false;
 
+  /** Generated Token Manager. */
+  public NginxConfigParserTokenManager token_source;
+  SimpleCharStream jj_input_stream;
+  /** Current token. */
+  public Token token;
+  /** Next token. */
+  public Token jj_nt;
+  private int jj_ntk;
+  private Token jj_scanpos, jj_lastpos;
+  private int jj_la;
+  private int jj_gen;
+  final private int[] jj_la1 = new int[10];
+  static private int[] jj_la1_0;
+  final private JJCalls[] jj_2_rtns = new JJCalls[3];
+  private boolean jj_rescan = false;
+  private int jj_gc = 0;
+
+  private java.util.List<int[]> jj_expentries = new java.util.ArrayList<int[]>();
+  private int[] jj_expentry;
+  private int jj_kind = -1;
+  private int[] jj_lasttokens = new int[100];
+  private int jj_endpos;
+
+  final private LookaheadSuccess jj_ls = new LookaheadSuccess();
+
+  /** Constructor with InputStream. */
+  public NginxConfigParser(java.io.InputStream stream) {
+        this(stream, null);
+    }
+  /** Constructor with InputStream and supplied encoding */
+  public NginxConfigParser(java.io.InputStream stream, String encoding) {
+      try { jj_input_stream = new SimpleCharStream(stream, encoding, 1, 1); } catch(java.io.UnsupportedEncodingException e) { throw new RuntimeException(e); }
+      token_source = new NginxConfigParserTokenManager(jj_input_stream);
+      token = new Token();
+      jj_ntk = -1;
+      jj_gen = 0;
+      for (int i = 0; i < 10; i++) jj_la1[i] = -1;
+      for (int i = 0; i < jj_2_rtns.length; i++) jj_2_rtns[i] = new JJCalls();
+  }
+
+  /** Constructor. */
+  public NginxConfigParser(java.io.Reader stream) {
+      jj_input_stream = new SimpleCharStream(stream, 1, 1);
+      token_source = new NginxConfigParserTokenManager(jj_input_stream);
+      token = new Token();
+      jj_ntk = -1;
+      jj_gen = 0;
+      for (int i = 0; i < 10; i++) jj_la1[i] = -1;
+      for (int i = 0; i < jj_2_rtns.length; i++) jj_2_rtns[i] = new JJCalls();
+  }
+
+  /** Constructor with generated Token Manager. */
+  public NginxConfigParser(NginxConfigParserTokenManager tm) {
+      token_source = tm;
+      token = new Token();
+      jj_ntk = -1;
+      jj_gen = 0;
+      for (int i = 0; i < 10; i++) jj_la1[i] = -1;
+      for (int i = 0; i < jj_2_rtns.length; i++) jj_2_rtns[i] = new JJCalls();
+  }
+
+  static {
+      jj_la1_init_0();
+  }
   public void setDebug(boolean val) {
     isDebug = val;
   }
@@ -421,42 +485,8 @@ debugLn("COMMENT=" + token.image);
     return false;
   }
 
-  /** Generated Token Manager. */
-  public NginxConfigParserTokenManager token_source;
-  SimpleCharStream jj_input_stream;
-  /** Current token. */
-  public Token token;
-  /** Next token. */
-  public Token jj_nt;
-  private int jj_ntk;
-  private Token jj_scanpos, jj_lastpos;
-  private int jj_la;
-  private int jj_gen;
-  final private int[] jj_la1 = new int[10];
-  static private int[] jj_la1_0;
-  static {
-      jj_la1_init_0();
-   }
-   private static void jj_la1_init_0() {
-      jj_la1_0 = new int[] {0x1e000,0x1e000,0xe000,0x1e400,0x1e400,0x1e000,0x1e000,0xf000,0xe000,0xf000,};
-   }
-  final private JJCalls[] jj_2_rtns = new JJCalls[3];
-  private boolean jj_rescan = false;
-  private int jj_gc = 0;
-
-  /** Constructor with InputStream. */
-  public NginxConfigParser(java.io.InputStream stream) {
-     this(stream, null);
-  }
-  /** Constructor with InputStream and supplied encoding */
-  public NginxConfigParser(java.io.InputStream stream, String encoding) {
-    try { jj_input_stream = new SimpleCharStream(stream, encoding, 1, 1); } catch(java.io.UnsupportedEncodingException e) { throw new RuntimeException(e); }
-    token_source = new NginxConfigParserTokenManager(jj_input_stream);
-    token = new Token();
-    jj_ntk = -1;
-    jj_gen = 0;
-    for (int i = 0; i < 10; i++) jj_la1[i] = -1;
-    for (int i = 0; i < jj_2_rtns.length; i++) jj_2_rtns[i] = new JJCalls();
+  private static void jj_la1_init_0() {
+     jj_la1_0 = new int[] {0x1e000,0x1e000,0xe000,0x1e400,0x1e400,0x1e000,0x1e000,0xf000,0xe000,0xf000,};
   }
 
   /** Reinitialise. */
@@ -474,31 +504,10 @@ debugLn("COMMENT=" + token.image);
     for (int i = 0; i < jj_2_rtns.length; i++) jj_2_rtns[i] = new JJCalls();
   }
 
-  /** Constructor. */
-  public NginxConfigParser(java.io.Reader stream) {
-    jj_input_stream = new SimpleCharStream(stream, 1, 1);
-    token_source = new NginxConfigParserTokenManager(jj_input_stream);
-    token = new Token();
-    jj_ntk = -1;
-    jj_gen = 0;
-    for (int i = 0; i < 10; i++) jj_la1[i] = -1;
-    for (int i = 0; i < jj_2_rtns.length; i++) jj_2_rtns[i] = new JJCalls();
-  }
-
   /** Reinitialise. */
   public void ReInit(java.io.Reader stream) {
     jj_input_stream.ReInit(stream, 1, 1);
     token_source.ReInit(jj_input_stream);
-    token = new Token();
-    jj_ntk = -1;
-    jj_gen = 0;
-    for (int i = 0; i < 10; i++) jj_la1[i] = -1;
-    for (int i = 0; i < jj_2_rtns.length; i++) jj_2_rtns[i] = new JJCalls();
-  }
-
-  /** Constructor with generated Token Manager. */
-  public NginxConfigParser(NginxConfigParserTokenManager tm) {
-    token_source = tm;
     token = new Token();
     jj_ntk = -1;
     jj_gen = 0;
@@ -542,7 +551,6 @@ debugLn("COMMENT=" + token.image);
 
   @SuppressWarnings("serial")
   static private final class LookaheadSuccess extends java.lang.Error { }
-  final private LookaheadSuccess jj_ls = new LookaheadSuccess();
   private boolean jj_scan_token(int kind) {
     if (jj_scanpos == jj_lastpos) {
       jj_la--;
@@ -590,12 +598,6 @@ debugLn("COMMENT=" + token.image);
     else
       return (jj_ntk = jj_nt.kind);
   }
-
-  private java.util.List<int[]> jj_expentries = new java.util.ArrayList<int[]>();
-  private int[] jj_expentry;
-  private int jj_kind = -1;
-  private int[] jj_lasttokens = new int[100];
-  private int jj_endpos;
 
   private void jj_add_error_token(int kind, int pos) {
     if (pos >= 100) return;

--- a/src/main/java/com/github/odiszapc/nginxparser/javacc/NginxConfigParserTokenManager.java
+++ b/src/main/java/com/github/odiszapc/nginxparser/javacc/NginxConfigParserTokenManager.java
@@ -7,8 +7,61 @@ package com.github.odiszapc.nginxparser.javacc;
 
   /** Debug output. */
   public  java.io.PrintStream debugStream = System.out;
+
+  static final int[] jjnextStates = {
+          7, 8, 10, 7, 8, 12, 10, 9, 11, 13, 16, 17,
+  };
+
+  /** Token literal values. */
+  public static final String[] jjstrLiteralImages = {
+          "", null, null, null, null, "\50", "\51", "\173", "\175", "\73", "\151\146",
+          null, null, null, null, null, null, null, null, };
+
+  static final long[] jjbitVec0 = {
+          0x0L, 0x0L, 0xffffffffffffffffL, 0xffffffffffffffffL
+  };
+
+  int curLexState = 0;
+  int defaultLexState = 0;
+  int jjnewStateCnt;
+  int jjround;
+  int jjmatchedPos;
+  int jjmatchedKind;
+
+  /** Lexer state names. */
+  public static final String[] lexStateNames = {
+          "DEFAULT",
+  };
+  static final long[] jjtoToken = {
+          0x1ffe1L,
+  };
+  static final long[] jjtoSkip = {
+          0x1eL,
+  };
+  protected SimpleCharStream  input_stream;
+
+  private final int[] jjrounds = new int[20];
+  private final int[] jjstateSet = new int[2 * 20];
+
+  protected char curChar;
+
+  /** Constructor. */
+  public NginxConfigParserTokenManager(SimpleCharStream stream) {
+       if (SimpleCharStream.staticFlag)
+          throw new Error("ERROR: Cannot use a static CharStream class with a non-static lexical analyzer.");
+
+      input_stream = stream;
+  }
+
+  /** Constructor. */
+  public NginxConfigParserTokenManager (SimpleCharStream stream, int lexState){
+      ReInit(stream);
+      SwitchTo(lexState);
+  }
+
   /** Set debug output. */
   public  void setDebugStream(java.io.PrintStream ds) { debugStream = ds; }
+
 private final int jjStopStringLiteralDfa_0(int pos, long active0){
    switch (pos)
    {
@@ -80,9 +133,7 @@ private int jjStartNfaWithStates_0(int pos, int kind, int state)
    catch(java.io.IOException e) { return pos + 1; }
    return jjMoveNfa_0(state, pos + 1);
 }
-static final long[] jjbitVec0 = {
-   0x0L, 0x0L, 0xffffffffffffffffL, 0xffffffffffffffffL
-};
+
 private int jjMoveNfa_0(int startState, int curPos)
 {
    int startsAt = 0;
@@ -324,14 +375,7 @@ private int jjMoveNfa_0(int startState, int curPos)
       catch(java.io.IOException e) { return curPos; }
    }
 }
-static final int[] jjnextStates = {
-   7, 8, 10, 7, 8, 12, 10, 9, 11, 13, 16, 17, 
-};
 
-/** Token literal values. */
-public static final String[] jjstrLiteralImages = {
-"", null, null, null, null, "\50", "\51", "\173", "\175", "\73", "\151\146", 
-null, null, null, null, null, null, null, null, };
 protected Token jjFillToken()
 {
    final Token t;
@@ -355,13 +399,6 @@ protected Token jjFillToken()
 
    return t;
 }
-
-int curLexState = 0;
-int defaultLexState = 0;
-int jjnewStateCnt;
-int jjround;
-int jjmatchedPos;
-int jjmatchedKind;
 
 /** Get the next Token. */
 public Token getNextToken() 
@@ -456,21 +493,6 @@ private void jjCheckNAddStates(int start, int end)
    } while (start++ != end);
 }
 
-    /** Constructor. */
-    public NginxConfigParserTokenManager(SimpleCharStream stream){
-
-      if (SimpleCharStream.staticFlag)
-            throw new Error("ERROR: Cannot use a static CharStream class with a non-static lexical analyzer.");
-
-    input_stream = stream;
-  }
-
-  /** Constructor. */
-  public NginxConfigParserTokenManager (SimpleCharStream stream, int lexState){
-    ReInit(stream);
-    SwitchTo(lexState);
-  }
-
   /** Reinitialise parser. */
   public void ReInit(SimpleCharStream stream)
   {
@@ -503,22 +525,4 @@ private void jjCheckNAddStates(int start, int end)
     else
       curLexState = lexState;
   }
-
-/** Lexer state names. */
-public static final String[] lexStateNames = {
-   "DEFAULT",
-};
-static final long[] jjtoToken = {
-   0x1ffe1L, 
-};
-static final long[] jjtoSkip = {
-   0x1eL, 
-};
-    protected SimpleCharStream  input_stream;
-
-    private final int[] jjrounds = new int[20];
-    private final int[] jjstateSet = new int[2 * 20];
-
-    
-    protected char curChar;
 }

--- a/src/main/java/com/github/odiszapc/nginxparser/javacc/ParseException.java
+++ b/src/main/java/com/github/odiszapc/nginxparser/javacc/ParseException.java
@@ -37,6 +37,32 @@ public class ParseException extends Exception {
   private static final long serialVersionUID = 1L;
 
   /**
+   * This is the last token that has been consumed successfully.  If
+   * this object has been created due to a parse error, the token
+   * followng this token will (therefore) be the first error token.
+   */
+  public Token currentToken;
+
+  /**
+   * Each entry in this array is an array of integers.  Each array
+   * of integers represents a sequence of tokens (by their ordinal
+   * values) that is expected at this point of the parse.
+   */
+  public int[][] expectedTokenSequences;
+
+  /**
+   * This is a reference to the "tokenImage" array of the generated
+   * parser within which the parse error occurred.  This array is
+   * defined in the generated ...Constants interface.
+   */
+  public String[] tokenImage;
+
+  /**
+   * The end of line string for this machine.
+   */
+  protected String eol = System.getProperty("line.separator", "\n");
+
+  /**
    * This constructor is used by the method "generateParseException"
    * in the generated parser.  Calling this constructor generates
    * a new object of this type with the fields "currentToken",
@@ -71,28 +97,6 @@ public class ParseException extends Exception {
   public ParseException(String message) {
     super(message);
   }
-
-
-  /**
-   * This is the last token that has been consumed successfully.  If
-   * this object has been created due to a parse error, the token
-   * followng this token will (therefore) be the first error token.
-   */
-  public Token currentToken;
-
-  /**
-   * Each entry in this array is an array of integers.  Each array
-   * of integers represents a sequence of tokens (by their ordinal
-   * values) that is expected at this point of the parse.
-   */
-  public int[][] expectedTokenSequences;
-
-  /**
-   * This is a reference to the "tokenImage" array of the generated
-   * parser within which the parse error occurred.  This array is
-   * defined in the generated ...Constants interface.
-   */
-  public String[] tokenImage;
 
   /**
    * It uses "currentToken" and "expectedTokenSequences" to generate a parse
@@ -143,11 +147,6 @@ public class ParseException extends Exception {
     retval += expected.toString();
     return retval;
   }
-
-  /**
-   * The end of line string for this machine.
-   */
-  protected String eol = System.getProperty("line.separator", "\n");
 
   /**
    * Used to convert raw characters to their escaped version

--- a/src/main/java/com/github/odiszapc/nginxparser/javacc/SimpleCharStream.java
+++ b/src/main/java/com/github/odiszapc/nginxparser/javacc/SimpleCharStream.java
@@ -49,6 +49,72 @@ public class SimpleCharStream
   protected int tabSize = 8;
   protected boolean trackLineColumn = true;
 
+  /** Constructor. */
+  public SimpleCharStream(java.io.Reader dstream, int startline,
+                          int startcolumn, int buffersize)
+  {
+    inputStream = dstream;
+    line = startline;
+    column = startcolumn - 1;
+
+    available = bufsize = buffersize;
+    buffer = new char[buffersize];
+    bufline = new int[buffersize];
+    bufcolumn = new int[buffersize];
+  }
+
+  /** Constructor. */
+  public SimpleCharStream(java.io.Reader dstream, int startline,
+                          int startcolumn)
+  {
+    this(dstream, startline, startcolumn, 4096);
+  }
+
+  /** Constructor. */
+  public SimpleCharStream(java.io.Reader dstream)
+  {
+    this(dstream, 1, 1, 4096);
+  }
+  /** Constructor. */
+  public SimpleCharStream(java.io.InputStream dstream, String encoding, int startline,
+                          int startcolumn, int buffersize) throws java.io.UnsupportedEncodingException
+  {
+    this(encoding == null ? new java.io.InputStreamReader(dstream) : new java.io.InputStreamReader(dstream, encoding), startline, startcolumn, buffersize);
+  }
+
+  /** Constructor. */
+  public SimpleCharStream(java.io.InputStream dstream, int startline,
+                          int startcolumn, int buffersize)
+  {
+    this(new java.io.InputStreamReader(dstream), startline, startcolumn, buffersize);
+  }
+
+  /** Constructor. */
+  public SimpleCharStream(java.io.InputStream dstream, String encoding, int startline,
+                          int startcolumn) throws java.io.UnsupportedEncodingException
+  {
+    this(dstream, encoding, startline, startcolumn, 4096);
+  }
+
+  /** Constructor. */
+  public SimpleCharStream(java.io.InputStream dstream, int startline,
+                          int startcolumn)
+  {
+    this(dstream, startline, startcolumn, 4096);
+  }
+
+  /** Constructor. */
+  public SimpleCharStream(java.io.InputStream dstream, String encoding) throws java.io.UnsupportedEncodingException
+  {
+    this(dstream, encoding, 1, 1, 4096);
+  }
+
+  /** Constructor. */
+  public SimpleCharStream(java.io.InputStream dstream)
+  {
+    this(dstream, 1, 1, 4096);
+  }
+
   public void setTabSize(int i) { tabSize = i; }
   public int getTabSize() { return tabSize; }
 
@@ -266,33 +332,6 @@ public class SimpleCharStream
       bufpos += bufsize;
   }
 
-  /** Constructor. */
-  public SimpleCharStream(java.io.Reader dstream, int startline,
-  int startcolumn, int buffersize)
-  {
-    inputStream = dstream;
-    line = startline;
-    column = startcolumn - 1;
-
-    available = bufsize = buffersize;
-    buffer = new char[buffersize];
-    bufline = new int[buffersize];
-    bufcolumn = new int[buffersize];
-  }
-
-  /** Constructor. */
-  public SimpleCharStream(java.io.Reader dstream, int startline,
-                          int startcolumn)
-  {
-    this(dstream, startline, startcolumn, 4096);
-  }
-
-  /** Constructor. */
-  public SimpleCharStream(java.io.Reader dstream)
-  {
-    this(dstream, 1, 1, 4096);
-  }
-
   /** Reinitialise. */
   public void ReInit(java.io.Reader dstream, int startline,
   int startcolumn, int buffersize)
@@ -324,45 +363,6 @@ public class SimpleCharStream
   public void ReInit(java.io.Reader dstream)
   {
     ReInit(dstream, 1, 1, 4096);
-  }
-  /** Constructor. */
-  public SimpleCharStream(java.io.InputStream dstream, String encoding, int startline,
-  int startcolumn, int buffersize) throws java.io.UnsupportedEncodingException
-  {
-    this(encoding == null ? new java.io.InputStreamReader(dstream) : new java.io.InputStreamReader(dstream, encoding), startline, startcolumn, buffersize);
-  }
-
-  /** Constructor. */
-  public SimpleCharStream(java.io.InputStream dstream, int startline,
-  int startcolumn, int buffersize)
-  {
-    this(new java.io.InputStreamReader(dstream), startline, startcolumn, buffersize);
-  }
-
-  /** Constructor. */
-  public SimpleCharStream(java.io.InputStream dstream, String encoding, int startline,
-                          int startcolumn) throws java.io.UnsupportedEncodingException
-  {
-    this(dstream, encoding, startline, startcolumn, 4096);
-  }
-
-  /** Constructor. */
-  public SimpleCharStream(java.io.InputStream dstream, int startline,
-                          int startcolumn)
-  {
-    this(dstream, startline, startcolumn, 4096);
-  }
-
-  /** Constructor. */
-  public SimpleCharStream(java.io.InputStream dstream, String encoding) throws java.io.UnsupportedEncodingException
-  {
-    this(dstream, encoding, 1, 1, 4096);
-  }
-
-  /** Constructor. */
-  public SimpleCharStream(java.io.InputStream dstream)
-  {
-    this(dstream, 1, 1, 4096);
   }
 
   /** Reinitialise. */

--- a/src/main/java/com/github/odiszapc/nginxparser/javacc/Token.java
+++ b/src/main/java/com/github/odiszapc/nginxparser/javacc/Token.java
@@ -77,18 +77,6 @@ public class Token implements java.io.Serializable {
   public Token specialToken;
 
   /**
-   * An optional attribute value of the Token.
-   * Tokens which are not used as syntactic sugar will often contain
-   * meaningful values that will be used later on by the compiler or
-   * interpreter. This attribute value is often different from the image.
-   * Any subclass of Token that actually wants to return a non-null value can
-   * override this method as appropriate.
-   */
-  public Object getValue() {
-    return null;
-  }
-
-  /**
    * No-argument constructor
    */
   public Token() {}
@@ -108,6 +96,18 @@ public class Token implements java.io.Serializable {
   {
     this.kind = kind;
     this.image = image;
+  }
+
+  /**
+   * An optional attribute value of the Token.
+   * Tokens which are not used as syntactic sugar will often contain
+   * meaningful values that will be used later on by the compiler or
+   * interpreter. This attribute value is often different from the image.
+   * Any subclass of Token that actually wants to return a non-null value can
+   * override this method as appropriate.
+   */
+  public Object getValue() {
+    return null;
   }
 
   /**

--- a/src/main/java/com/github/odiszapc/nginxparser/javacc/TokenMgrError.java
+++ b/src/main/java/com/github/odiszapc/nginxparser/javacc/TokenMgrError.java
@@ -59,6 +59,25 @@ public class TokenMgrError extends Error
    */
   int errorCode;
 
+  /*
+   * Constructors of various flavors follow.
+   */
+
+  /** No arg constructor. */
+  public TokenMgrError() {
+  }
+
+  /** Constructor with message and reason. */
+  public TokenMgrError(String message, int reason) {
+    super(message);
+    errorCode = reason;
+  }
+
+  /** Full Constructor. */
+  public TokenMgrError(boolean EOFSeen, int lexState, int errorLine, int errorColumn, String errorAfter, char curChar, int reason) {
+    this(LexicalError(EOFSeen, lexState, errorLine, errorColumn, errorAfter, curChar), reason);
+  }
+
   /**
    * Replaces unprintable characters by their escaped (or unicode escaped)
    * equivalents in the given string
@@ -139,25 +158,6 @@ public class TokenMgrError extends Error
    */
   public String getMessage() {
     return super.getMessage();
-  }
-
-  /*
-   * Constructors of various flavors follow.
-   */
-
-  /** No arg constructor. */
-  public TokenMgrError() {
-  }
-
-  /** Constructor with message and reason. */
-  public TokenMgrError(String message, int reason) {
-    super(message);
-    errorCode = reason;
-  }
-
-  /** Full Constructor. */
-  public TokenMgrError(boolean EOFSeen, int lexState, int errorLine, int errorColumn, String errorAfter, char curChar, int reason) {
-    this(LexicalError(EOFSeen, lexState, errorLine, errorColumn, errorAfter, curChar), reason);
   }
 }
 /* JavaCC - OriginalChecksum=5f0ac55433b166fece155f995c9aa2a9 (do not edit this line) */


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1213
Please let me know if you have any questions.
George Kankava
