### PR TITLE
[BUGFIX,ISSUE-26] Dump with If blocks now are written correctly | Slight Dumping rework 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,8 +89,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.5.1</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>com.github.odiszapc</groupId>
     <artifactId>nginxparser</artifactId>
-    <version>0.9.6</version>
+    <version>0.9.7</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -89,8 +89,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.5.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>

--- a/src/main/java/com/github/odiszapc/nginxparser/NgxAbstractEntry.java
+++ b/src/main/java/com/github/odiszapc/nginxparser/NgxAbstractEntry.java
@@ -22,7 +22,7 @@ import java.util.Iterator;
 import java.util.List;
 
 public abstract class NgxAbstractEntry implements NgxEntry {
-    private Collection<NgxToken> tokens = new ArrayList<NgxToken>();
+    private Collection<NgxToken> tokens = new ArrayList<>();
 
     public NgxAbstractEntry(String... rawValues) {
         for (String val : rawValues) {

--- a/src/main/java/com/github/odiszapc/nginxparser/NgxBlock.java
+++ b/src/main/java/com/github/odiszapc/nginxparser/NgxBlock.java
@@ -37,7 +37,7 @@ public class NgxBlock extends NgxAbstractEntry implements Iterable<NgxEntry> {
 
     @Override
     public String toString() {
-        return super.toString() + " {";
+        return super.toString();
     }
 
 
@@ -139,5 +139,12 @@ public class NgxBlock extends NgxAbstractEntry implements Iterable<NgxEntry> {
         }
 
         return res;
+    }
+
+    @Override
+    public void write(NgxPrintWriter writer) {
+        writer.openBlock(toString())
+            .write(getEntries())
+            .closeBlock();
     }
 }

--- a/src/main/java/com/github/odiszapc/nginxparser/NgxComment.java
+++ b/src/main/java/com/github/odiszapc/nginxparser/NgxComment.java
@@ -34,4 +34,9 @@ public class NgxComment extends NgxAbstractEntry {
     public String toString() {
         return "#" + getValue();
     }
+
+    @Override
+    public void write(NgxPrintWriter printWriter) {
+        printWriter.appendLine(toString());
+    }
 }

--- a/src/main/java/com/github/odiszapc/nginxparser/NgxDumper.java
+++ b/src/main/java/com/github/odiszapc/nginxparser/NgxDumper.java
@@ -79,8 +79,9 @@ public class NgxDumper {
                     writeToStream(ifBlock, writer, level + 1);
                     writer
                             .append(getOffset(level))
-                            .append(LBRACE)
+                            .append(RBRACE)
                             .append(getLineEnding());
+                    break;
                 case COMMENT:
                 case PARAM:
                     writer

--- a/src/main/java/com/github/odiszapc/nginxparser/NgxDumper.java
+++ b/src/main/java/com/github/odiszapc/nginxparser/NgxDumper.java
@@ -75,6 +75,7 @@ public class NgxDumper {
                     writer
                             .append(getOffset(level))
                             .append(ifBlock.toString())
+                            .append(LBRACE)
                             .append(getLineEnding());
                     writeToStream(ifBlock, writer, level + 1);
                     writer

--- a/src/main/java/com/github/odiszapc/nginxparser/NgxDumper.java
+++ b/src/main/java/com/github/odiszapc/nginxparser/NgxDumper.java
@@ -16,9 +16,14 @@
 
 package com.github.odiszapc.nginxparser;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.OutputStream;
-import java.io.PrintWriter;
-import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.Iterator;
 
 /**
  * NgxDumper is used to serialize an existing or manually created NgxConfig object
@@ -26,84 +31,81 @@ import java.io.StringWriter;
 public class NgxDumper {
 
     private NgxConfig config;
-    private final static int PAD_SIZE = 2;
-    private final static String PAD_SYMBOL = "  ";
-    private final static String LBRACE = "{";
-    private final static String RBRACE = "}";
-    private final static String LF = "\n";
-    private final static String CRLF = "\r\n";
 
     public NgxDumper(NgxConfig config) {
         this.config = config;
     }
 
     /**
+     * Dump the content of the config to a file.
+     *
+     * This method is used to write the NgxConfig directly to a file.
+     *
+     * If the file does not exist, it will be created.
+     *
+     * @param path the {@link Path} the config should be written to
+     * @throws IOException if anything goes wrong while writing or if the file is not writable
+     */
+    public void dumpToFile(Path path) throws IOException {
+        if(!Files.exists(path)) {
+            Files.createFile(path);
+        }
+        if(!Files.isWritable(path)) {
+            throw new IOException("The file cannot be written to: " + path);
+        }
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        dump(outputStream);
+        Files.write(path, outputStream.toByteArray(), StandardOpenOption.TRUNCATE_EXISTING);
+    }
+
+    /**
+     * Dump the content of the config to a file.
+     *
+     * This method is for convenience and redirects directly to {@link #dumpToFile(Path)}
+     *
+     * @param destination the file the config should be written to
+     * @throws IOException if anything goes wrong while writing
+     * @see #dumpToFile(Path)
+     */
+    public void dumpToFile(String destination) throws IOException {
+        dumpToFile(Paths.get(destination));
+    }
+
+    /**
      * Converts config int String
+     *
      * @return Serialized config
      */
     public String dump() {
-        StringWriter writer = new StringWriter();
-        writeToStream(config, new PrintWriter(writer), 0);
-        return writer.toString();
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        writeToStream(config, outputStream);
+        return outputStream.toString();
     }
 
     /**
      * Serializes config and sends result to the provided OutputStream
+     *
      * @param out stream to write to
      */
     public void dump(OutputStream out) {
-        writeToStream(config, new PrintWriter(out), 0);
+        writeToStream(config, out);
     }
 
-    private void writeToStream(NgxBlock config, PrintWriter writer, int level) {
-        for (NgxEntry entry : config) {
-            NgxEntryType type = NgxEntryType.fromClass(entry.getClass());
-            switch (type) {
-                case BLOCK:
-                    NgxBlock block = (NgxBlock) entry;
-                    writer.append(getOffset(level))
-                            .append(block.toString())
-                            .append(getLineEnding());
-                    writeToStream(block, writer, level + 1);
-                    writer
-                            .append(getOffset(level))
-                            .append(RBRACE)
-                            .append(getLineEnding());
-                    break;
-                case IF:
-                    NgxIfBlock ifBlock = (NgxIfBlock) entry;
-                    writer
-                            .append(getOffset(level))
-                            .append(ifBlock.toString())
-                            .append(LBRACE)
-                            .append(getLineEnding());
-                    writeToStream(ifBlock, writer, level + 1);
-                    writer
-                            .append(getOffset(level))
-                            .append(RBRACE)
-                            .append(getLineEnding());
-                    break;
-                case COMMENT:
-                case PARAM:
-                    writer
-                            .append(getOffset(level))
-                            .append(entry.toString())
-                            .append(getLineEnding());
-                    break;
+    private void writeToStream(NgxBlock config, OutputStream outputStream) {
+        try (NgxPrintWriter writer = new NgxPrintWriter(outputStream)) {
+            Iterator<NgxEntry> iterator = config.iterator();
+            while (iterator.hasNext()) {
+                NgxEntry current = iterator.next();
+                current.write(writer);
+                if (current instanceof NgxBlock && iterator.hasNext()) {
+                    // Extra new line, between two top level blocks
+                    writer.newLine();
+                }
             }
+        } catch (Exception e) {
+            // TODO Better Exception handling, like custom Exception types within a custom hierarchy
+            throw new IllegalStateException(e);
         }
-        writer.flush();
-    }
-
-    public String getOffset(int level) {
-        String offset = "";
-        for (int i = 0; i < level; i++) {
-            offset += PAD_SYMBOL;
-        }
-        return offset;
-    }
-
-    public String getLineEnding() {
-        return LF;
     }
 }

--- a/src/main/java/com/github/odiszapc/nginxparser/NgxEntry.java
+++ b/src/main/java/com/github/odiszapc/nginxparser/NgxEntry.java
@@ -16,7 +16,6 @@
 
 package com.github.odiszapc.nginxparser;
 
-
 public interface NgxEntry {
-
+    void write(NgxPrintWriter printWriter);
 }

--- a/src/main/java/com/github/odiszapc/nginxparser/NgxIfBlock.java
+++ b/src/main/java/com/github/odiszapc/nginxparser/NgxIfBlock.java
@@ -16,9 +16,23 @@
 
 package com.github.odiszapc.nginxparser;
 
+import java.util.ArrayList;
+
 public class NgxIfBlock extends NgxBlock {
 
     public String toString() {
-        return super.toString(); // TODO: add parentheses (looks like "if $a !~ ^1(2)3$ {" currently)
+        ArrayList<NgxToken> tokens = new ArrayList<>(getTokens());
+        String ifToken = tokens.remove(0).getToken(); // The "if"
+        StringBuilder tokenBuilder = new StringBuilder(ifToken)
+                .append(" ")
+                .append("(");
+
+        for (NgxToken value : tokens) {
+            tokenBuilder.append(value).append(" ");
+        }
+
+        String result = tokenBuilder.toString();
+
+        return result.substring(0, result.length() -1) + ") ";
     }
 }

--- a/src/main/java/com/github/odiszapc/nginxparser/NgxIfBlock.java
+++ b/src/main/java/com/github/odiszapc/nginxparser/NgxIfBlock.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 
 public class NgxIfBlock extends NgxBlock {
 
+    @Override
     public String toString() {
         ArrayList<NgxToken> tokens = new ArrayList<>(getTokens());
         String ifToken = tokens.remove(0).getToken(); // The "if"
@@ -33,6 +34,6 @@ public class NgxIfBlock extends NgxBlock {
 
         String result = tokenBuilder.toString();
 
-        return result.substring(0, result.length() -1) + ") ";
+        return result.substring(0, result.length() -1) + ")";
     }
 }

--- a/src/main/java/com/github/odiszapc/nginxparser/NgxParam.java
+++ b/src/main/java/com/github/odiszapc/nginxparser/NgxParam.java
@@ -30,4 +30,9 @@ public class NgxParam extends NgxAbstractEntry {
 
         return s + ";";
     }
+
+    @Override
+    public void write(NgxPrintWriter printWriter) {
+        printWriter.appendLine(toString());
+    }
 }

--- a/src/main/java/com/github/odiszapc/nginxparser/NgxPrintWriter.java
+++ b/src/main/java/com/github/odiszapc/nginxparser/NgxPrintWriter.java
@@ -1,0 +1,80 @@
+package com.github.odiszapc.nginxparser;
+
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.util.Collection;
+
+public class NgxPrintWriter implements AutoCloseable {
+
+    private final static String PAD_SYMBOL = "  ";
+    private final static String LBRACE = "{";
+    private final static String RBRACE = "}";
+    private final static String LF = "\n";
+    private final PrintWriter printWriter;
+    private int level = 0;
+
+    public NgxPrintWriter(OutputStream outputStream) {
+        this.printWriter = new PrintWriter(outputStream);
+    }
+
+    public NgxPrintWriter openBlock(String prefix) {
+        append(prefix);
+        printWriter.append(" ").append(LBRACE);
+        level += 1;
+
+        return newLine();
+    }
+
+    public NgxPrintWriter closeBlock() {
+        level -= 1;
+        append(RBRACE);
+
+        return newLine();
+    }
+
+    public NgxPrintWriter newLine() {
+        printWriter.append(LF);
+
+        return this;
+    }
+
+    public NgxPrintWriter append(String string) {
+        this.printWriter.append(constructOffset(level))
+                .append(string);
+
+        return this;
+    }
+
+    public NgxPrintWriter appendLine(String string) {
+        this.printWriter.append(constructOffset(level))
+                .append(string)
+                .append(LF);
+
+        return this;
+    }
+
+    public NgxPrintWriter write(Collection<NgxEntry> entries) {
+        for (NgxEntry entry : entries) {
+            entry.write(this);
+        }
+
+        return this;
+    }
+
+    public void flush() {
+        printWriter.flush();
+    }
+
+    private String constructOffset(int level) {
+        StringBuilder offset = new StringBuilder();
+        for (int i = 0; i < level; i++) {
+            offset.append(PAD_SYMBOL);
+        }
+        return offset.toString();
+    }
+
+    @Override
+    public void close() {
+        printWriter.close();
+    }
+}

--- a/src/test/java/com/github/odiszapc/nginxparser/AlterConfigTest.java
+++ b/src/test/java/com/github/odiszapc/nginxparser/AlterConfigTest.java
@@ -21,7 +21,7 @@ public class AlterConfigTest extends ParseTestBase {
                 "  }\n" +
                 "}\n";
 
-        assertEquals(new NgxDumper(conf).dump(), expected);
+        assertEquals(expected, new NgxDumper(conf).dump());
     }
 
     @Test

--- a/src/test/java/com/github/odiszapc/nginxparser/DumperTest.java
+++ b/src/test/java/com/github/odiszapc/nginxparser/DumperTest.java
@@ -29,7 +29,7 @@ public class DumperTest {
                 "timer_resolution 100ms;\n" +
                 "worker_rlimit_nofile 8192;\n" +
                 "worker_priority -10;\n";
-        Assert.assertEquals(TestUtils.dump("common/c1.conf"), expected);
+        Assert.assertEquals(expected, TestUtils.dump("common/c1.conf"));
     }
 
     @Test
@@ -41,7 +41,7 @@ public class DumperTest {
                 "  worker_connections 2048;\n" +
                 "  use epoll;\n" +
                 "}\n";
-        Assert.assertEquals(TestUtils.dump("common/c2.conf"), expected);
+        Assert.assertEquals(expected, TestUtils.dump("common/c2.conf"));
     }
 
     @Test
@@ -51,6 +51,39 @@ public class DumperTest {
                 "#worker_processes  2;\n" +
                 "worker_priority -10;\n" +
                 "proxy_pass http://unix:/opt/apps/ipn/ipn.sock:/;\n";
-        Assert.assertEquals(TestUtils.dump("common/c3.conf"), expected);
+        Assert.assertEquals(expected, TestUtils.dump("common/c3.conf"));
+    }
+
+    @Test
+    public void testC8() throws Exception {
+        final String expected = "" +
+                "server {\n" +
+                "  if ($host == test.example.com) {\n" +
+                "    return 301 https://$host$request_uri;\n" +
+                "  }\n" +
+                "  # managed by certbot\n" +
+                ""+
+                "  listen 80;\n" +
+                "  return 404;\n" +
+                "  # managed by Certbot\n" +
+                "}\n" +
+                "\n" +
+                "server {\n" +
+                "  server_name test.example.com;\n" +
+                "  location / {\n" +
+                "    proxy_pass http://localhost:8080;\n" +
+                "  }\n" +
+                "  listen 443 ssl;\n" +
+                "  # managed by Certbot\n" +
+                "  ssl_certificate /etc/letsencrypt/live/example.com/fullchain.pem;\n" +
+                "  # managed by Certbot\n" +
+                "  ssl_certificate_key /etc/letsencrypt/live/example.com/privkey.pem;\n" +
+                "  # managed by Certbot\n" +
+                "  include /etc/letsencrypt/options-ssl-nginx.conf;\n" +
+                "  # managed by Certbot\n" +
+                "  ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;\n" +
+                "  # managed by Certbot\n" +
+                "}\n";
+        Assert.assertEquals(expected, TestUtils.dump("common/c8.conf"));
     }
 }

--- a/src/test/resources/common/c8.conf
+++ b/src/test/resources/common/c8.conf
@@ -1,0 +1,22 @@
+server { 
+  if ($host == test.example.com) {
+    return 301  https://$host$request_uri;
+  } # managed by certbot
+
+  listen 80;
+  return 404; # managed by Certbot
+}
+
+server {
+    server_name test.example.com;
+
+    location / {
+        proxy_pass http://localhost:8080;
+    }
+
+    listen 443 ssl; # managed by Certbot
+    ssl_certificate /etc/letsencrypt/live/example.com/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/example.com/privkey.pem; # managed by Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+}


### PR DESCRIPTION
This bugfix fixes https://github.com/odiszapc/nginx-java-parser/issues/26, https://github.com/odiszapc/nginx-java-parser/issues/16

The issue came because of a missing break in the case condition. Also, after the if there was an "opening" bracket introduced, instead of a closing one.
From the style of the code, there also might be another redesign in the pocket, that does not require a switch-case in the first place, thous eradicating any syntactic issue in the future.

Also, i bumped up the java version to 7, because 6 is no longer supported. One could think about bumping it up to 8, because there are some major things that come with it.